### PR TITLE
Add Telegram notification for new verification submissions

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -46,6 +46,9 @@ type Config struct {
 	NatsUrl string `envconfig:"NATS_URL"`
 
 	LogtoWebhookSecret string `envconfig:"LOGTO_WEBHOOK_SECRET"`
+
+	TelegramToken string `envconfig:"TELEGRAM_TOKEN"`
+	GroupId       string `envconfig:"GROUP_ID"`
 }
 
 // New initializes from .env and returns a new Config instance.


### PR DESCRIPTION
Introduced Telegram integration to send a message to a group when a player submits a new verification form. Added TELEGRAM_TOKEN and GROUP_ID to the config, and implemented SendToTelegram in the verification service to notify about new or updated verifications.