### PR TITLE
fix(auth): make users:batchGet and settlement tag reads public

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# buf embeds proto source comments verbatim into generated openapi/go output,
+# so CRLF in .proto leaks \r\n into descriptions. Force LF.
+*.proto text eol=lf

--- a/docs/v1/openapi.yaml
+++ b/docs/v1/openapi.yaml
@@ -3005,9 +3005,10 @@ paths:
     get:
       tags:
         - UserService
-      summary: Search users by query string.
+      summary: Search users by query string. Requires auth, since it enumerates players by name.
       description: |-
         Errors:
+           - UNAUTHENTICATED (401): missing or invalid auth token
            - INTERNAL (500): database failure
       operationId: UserService_SearchUsers
       parameters:

--- a/gen/user/v1/user_grpc.pb.go
+++ b/gen/user/v1/user_grpc.pb.go
@@ -57,9 +57,10 @@ type UserServiceClient interface {
 	//   - INVALID_ARGUMENT (400): user_ids is empty or has more than 100 entries
 	//   - INTERNAL (500): database failure
 	BatchGetUsers(ctx context.Context, in *BatchGetUsersRequest, opts ...grpc.CallOption) (*BatchGetUsersResponse, error)
-	// Search users by query string.
+	// Search users by query string. Requires auth, since it enumerates players by name.
 	//
 	// Errors:
+	//   - UNAUTHENTICATED (401): missing or invalid auth token
 	//   - INTERNAL (500): database failure
 	SearchUsers(ctx context.Context, in *SearchUsersRequest, opts ...grpc.CallOption) (*SearchUsersResponse, error)
 	// Change in-game nickname for a user. Caller must match user_id.
@@ -164,9 +165,10 @@ type UserServiceServer interface {
 	//   - INVALID_ARGUMENT (400): user_ids is empty or has more than 100 entries
 	//   - INTERNAL (500): database failure
 	BatchGetUsers(context.Context, *BatchGetUsersRequest) (*BatchGetUsersResponse, error)
-	// Search users by query string.
+	// Search users by query string. Requires auth, since it enumerates players by name.
 	//
 	// Errors:
+	//   - UNAUTHENTICATED (401): missing or invalid auth token
 	//   - INTERNAL (500): database failure
 	SearchUsers(context.Context, *SearchUsersRequest) (*SearchUsersResponse, error)
 	// Change in-game nickname for a user. Caller must match user_id.

--- a/internal/server/interceptor/matcher.go
+++ b/internal/server/interceptor/matcher.go
@@ -42,6 +42,14 @@ func AuthMatcher(ctx context.Context, c interceptors.CallMeta, cfg config.Config
 		return false
 	case "/user.v1.UserService/GetUser":
 		return false
+	case "/user.v1.UserService/BatchGetUsers":
+		return false
+	case "/settlement.v1.SettlementTagService/GetTag":
+		return false
+	case "/settlement.v1.SettlementTagService/GetTags":
+		return false
+	case "/settlement.v1.SettlementTagService/GetTagsByIds":
+		return false
 	case "/discord.v1.DiscordService/ListMessages":
 		return false
 	case "/discord.v1.DiscordService/ListImages":

--- a/internal/server/interceptor/matcher_test.go
+++ b/internal/server/interceptor/matcher_test.go
@@ -1,0 +1,43 @@
+package interceptor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
+	"github.com/lasthearth/vsservice/internal/pkg/config"
+)
+
+func TestAuthMatcherPublicMethods(t *testing.T) {
+	public := []string{
+		"/user.v1.UserService/GetUser",
+		"/user.v1.UserService/BatchGetUsers",
+		"/settlement.v1.SettlementService/List",
+		"/settlement.v1.SettlementTagService/GetTag",
+		"/settlement.v1.SettlementTagService/GetTags",
+		"/settlement.v1.SettlementTagService/GetTagsByIds",
+	}
+	protected := []string{
+		"/user.v1.UserService/SearchUsers",
+		"/user.v1.UserService/ChangeNickname",
+		"/settlement.v1.SettlementTagService/CreateTag",
+	}
+
+	split := func(m string) interceptors.CallMeta {
+		i := len(m) - 1
+		for ; i >= 0 && m[i] != '/'; i-- {
+		}
+		return interceptors.CallMeta{Service: m[1:i], Method: m[i+1:]}
+	}
+
+	for _, m := range public {
+		if AuthMatcher(context.Background(), split(m), config.Config{}) {
+			t.Errorf("%s must be public", m)
+		}
+	}
+	for _, m := range protected {
+		if !AuthMatcher(context.Background(), split(m), config.Config{}) {
+			t.Errorf("%s must require auth", m)
+		}
+	}
+}

--- a/proto/user/v1/user.proto
+++ b/proto/user/v1/user.proto
@@ -49,9 +49,10 @@ service UserService {
     option (google.api.http) = {get: "/v1/users:batchGet"};
   }
 
-  // Search users by query string.
+  // Search users by query string. Requires auth, since it enumerates players by name.
   //
   // Errors:
+  //   - UNAUTHENTICATED (401): missing or invalid auth token
   //   - INTERNAL (500): database failure
   rpc SearchUsers(SearchUsersRequest) returns (SearchUsersResponse) {
     option (google.api.http) = {get: "/v1/users/search"};


### PR DESCRIPTION
BatchGetUsers and the SettlementTagService read RPCs were missing from the auth matcher allowlist, so the public settlements page got 401 and rendered empty leaders, members and tags. They expose the same data as the already public GetUser and SettlementService/List.

SearchUsers stays behind auth since it enumerates players by name; the 401 is now documented in the proto and regenerated openapi.

Add .gitattributes forcing LF on .proto: buf copies proto comments verbatim into generated output, so CRLF leaked \r\n into openapi descriptions.